### PR TITLE
npm start and build commands added to package.json on server

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = () => {
         template: './index.html',
         title: 'JATE'
       }),
-      
+
       new WebpackPwaManifest({
         name: 'JATE',
         short_name: 'JATE',
@@ -57,6 +57,14 @@ module.exports = () => {
         {
           test: /\.css$/i,
           use: ['style-loader', 'css-loader']
+        },
+        {
+          test: /\.(png|svg|jpg|jpeg|gif)$/i,
+          type: 'asset/resource',
+          generator: {
+            // keep original filenames and copy images to `dist/img/`
+            filename: 'assets/icons/logo.png', 
+          },
         }
       ],
     },

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "server.js",
   "scripts": {
     "start:dev": "",
-    "start": "",
+    "start": "npm run build && cd server && node server.js",
     "server": "",
-    "build": "",
+    "build": "cd client && npm run build",
     "install": "",
     "client": ""
   },


### PR DESCRIPTION
The server is required to initialize on running the node command of `npm start`.  Running `npm start` from the server's directory through node calls the `npm run build && cd server && node server.js` script.  This script in turn references the `npm build` script  that initializes the command to `cd client && npm run build`.  This initializes webpack to bundle the application's files.  During testing, the command ran without errors and confirmed the server was listening on the specified port.