### PR TITLE
favicon added to build

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>J.A.T.E</title>
-    
+    <!-- This was added to the document to display the favicon -->
+    <link rel="icon" type="image/x-icon" href="./assets/icons/icon_512x512.png">
       <link rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.52.2/codemirror.min.css">
       </link>

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -34,7 +34,8 @@ module.exports = () => {
 
       new HtmlWebpackPlugin({
         template: './index.html',
-        title: 'JATE'
+        title: 'JATE',
+        favicon: './favicon.ico'
       }),
 
       new MiniCssExtractPlugin(),
@@ -65,7 +66,7 @@ module.exports = () => {
 
             // The purpose property is not required, but has to be set to "any" to allow for installation if included.
             purpose: 'any',
-          }
+          },
         ]
       }),
     ],
@@ -79,7 +80,7 @@ module.exports = () => {
           use: [MiniCssExtractPlugin.loader, 'css-loader']
         },
         {
-          test: /\.(png|svg|jpg|jpeg|gif)$/i,
+          test: /\.(png|svg|jpg|jpeg|gif|ico)$/i,
           type: 'asset/resource',
         },
         {


### PR DESCRIPTION
The favicon file included in the client files has been added to the build.  A property was added to the HTML webpack plugin to include the favicon.  This was done to resolve an issue producing a 404 error for the favicon on page load.  I also added a meta tag to the HTML to source a favicon for the page from the assets directory.