### PR TITLE
offline fallback added

### DIFF
--- a/client/src-sw.js
+++ b/client/src-sw.js
@@ -42,3 +42,7 @@ registerRoute(
     ],
   })
 );
+
+offlineFallback({
+  pageFallback: '/jate_offline.html',
+});


### PR DESCRIPTION
An offline fallback has been added to the src-sw.js file.  The offline fallback recipe sets up a Cache Only strategy that gets warmed with the provided fallbacks. It then sets up a Workbox default catch handler, catching any failed routing requests (if there's nothing in the cache and something can't be reached on the network), pulling the content of the relevant files from the cache and returning it as content as long as the request continues to fail.